### PR TITLE
Remove unnecessary try/catch

### DIFF
--- a/lesson-10/index.php
+++ b/lesson-10/index.php
@@ -19,14 +19,9 @@ $dsn = $config['dsn'];
 $username = $config['username'];
 $password = $config['password'];
 
-try {
-    $connection = new PDO($dsn, $username, $password);
-    $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    $connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
-} catch (PDOException $exception) {
-    echo 'Database error: ' . $exception->getMessage();
-    die();
-}
+$connection = new PDO($dsn, $username, $password);
+$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
 
 // Create app
 $app = AppFactory::create();

--- a/lesson-5/index.php
+++ b/lesson-5/index.php
@@ -17,14 +17,9 @@ $dsn = $config['dsn'];
 $username = $config['username'];
 $password = $config['password'];
 
-try {
-    $connection = new PDO($dsn, $username, $password);
-    $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    $connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
-} catch (PDOException $exception) {
-    echo 'Database error: ' . $exception->getMessage();
-    die();
-}
+$connection = new PDO($dsn, $username, $password);
+$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
 
 $postMapper = new PostMapper($connection);
 

--- a/lesson-6/index.php
+++ b/lesson-6/index.php
@@ -17,14 +17,9 @@ $dsn = $config['dsn'];
 $username = $config['username'];
 $password = $config['password'];
 
-try {
-    $connection = new PDO($dsn, $username, $password);
-    $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    $connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
-} catch (PDOException $exception) {
-    echo 'Database error: ' . $exception->getMessage();
-    die();
-}
+$connection = new PDO($dsn, $username, $password);
+$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
 
 $postMapper = new PostMapper($connection);
 

--- a/lesson-7/index.php
+++ b/lesson-7/index.php
@@ -18,14 +18,9 @@ $dsn = $config['dsn'];
 $username = $config['username'];
 $password = $config['password'];
 
-try {
-    $connection = new PDO($dsn, $username, $password);
-    $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    $connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
-} catch (PDOException $exception) {
-    echo 'Database error: ' . $exception->getMessage();
-    die();
-}
+$connection = new PDO($dsn, $username, $password);
+$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
 
 // Create app
 $app = AppFactory::create();

--- a/lesson-8/index.php
+++ b/lesson-8/index.php
@@ -18,14 +18,9 @@ $dsn = $config['dsn'];
 $username = $config['username'];
 $password = $config['password'];
 
-try {
-    $connection = new PDO($dsn, $username, $password);
-    $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    $connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
-} catch (PDOException $exception) {
-    echo 'Database error: ' . $exception->getMessage();
-    die();
-}
+$connection = new PDO($dsn, $username, $password);
+$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
 
 // Create app
 $app = AppFactory::create();

--- a/lesson-9/index.php
+++ b/lesson-9/index.php
@@ -19,14 +19,9 @@ $dsn = $config['dsn'];
 $username = $config['username'];
 $password = $config['password'];
 
-try {
-    $connection = new PDO($dsn, $username, $password);
-    $connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    $connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
-} catch (PDOException $exception) {
-    echo 'Database error: ' . $exception->getMessage();
-    die();
-}
+$connection = new PDO($dsn, $username, $password);
+$connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$connection->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
 
 // Create app
 $app = AppFactory::create();


### PR DESCRIPTION
Хочу предложить небольшое улучшение в ваш замечательный курс.
Я так понимаю что `echo 'Database error: ' . $exception->getMessage();` явно было сделано не намеренно а просто результат  copy/paste, но при этом вывод ошибки прямо на экран явно находится в противоречии с теми правильными подходами, которые в остальном пропагандирует этот курс. 